### PR TITLE
Fix Tailwind CSS setup and add R2 fallbacks

### DIFF
--- a/public/placeholder-image.svg
+++ b/public/placeholder-image.svg
@@ -1,0 +1,20 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#cbd5f5" />
+      <stop offset="100%" stop-color="#e2e8f0" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" rx="32" fill="url(#gradient)" />
+  <g opacity="0.2">
+    <circle cx="320" cy="220" r="140" fill="#1e293b" />
+    <circle cx="880" cy="280" r="180" fill="#1e293b" />
+    <circle cx="600" cy="520" r="200" fill="#1e293b" />
+  </g>
+  <rect x="260" y="240" width="680" height="360" rx="28" fill="#ffffff" opacity="0.85" />
+  <path d="M320 520L460 360L620 520L700 440L840 520" stroke="#94a3b8" stroke-width="16" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+  <circle cx="480" cy="420" r="36" fill="#cbd5f5" />
+  <text x="600" y="640" text-anchor="middle" fill="#1e293b" font-size="48" font-family="'Inter', sans-serif" opacity="0.8">
+    Photography preview unavailable
+  </text>
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,17 +1,14 @@
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 :root {
   --background: #ffffff;
   --foreground: #0f172a;
   --accent: #334155;
   --muted: #64748b;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-inter);
-  --font-serif: var(--font-playfair);
+  --font-inter: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  --font-playfair: "Playfair Display", "Georgia", "Times New Roman", serif;
 }
 
 * {
@@ -25,7 +22,7 @@ html {
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-inter), system-ui, sans-serif;
+  font-family: var(--font-inter);
   line-height: 1.6;
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,5 @@
 import type { Metadata } from "next";
-import { Inter, Playfair_Display } from "next/font/google";
 import "./globals.css";
-
-const inter = Inter({
-  variable: "--font-inter",
-  subsets: ["latin"],
-  display: "swap",
-});
-
-const playfair = Playfair_Display({
-  variable: "--font-playfair",
-  subsets: ["latin"],
-  display: "swap",
-});
 
 export const metadata: Metadata = {
   title: "Michael Haslim Photography - Fine Art Landscapes",
@@ -27,9 +14,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${inter.variable} ${playfair.variable} font-sans antialiased`}
-      >
+      <body className="font-sans antialiased">
         {children}
       </body>
     </html>

--- a/src/lib/r2-list.ts
+++ b/src/lib/r2-list.ts
@@ -1,22 +1,62 @@
-import { S3Client, ListObjectsV2Command } from '@aws-sdk/client-s3';
+import { ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3';
 
-export const r2Client = new S3Client({
-  region: 'auto',
-  endpoint: process.env.R2_ENDPOINT!,
-  credentials: {
-    accessKeyId: process.env.R2_ACCESS_KEY_ID!,
-    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
-  },
-});
+let cachedClient: S3Client | null = null;
+
+function getR2Client() {
+  if (
+    !process.env.R2_ENDPOINT ||
+    !process.env.R2_ACCESS_KEY_ID ||
+    !process.env.R2_SECRET_ACCESS_KEY ||
+    !process.env.R2_BUCKET
+  ) {
+    return null;
+  }
+
+  if (!cachedClient) {
+    cachedClient = new S3Client({
+      region: 'auto',
+      endpoint: process.env.R2_ENDPOINT,
+      credentials: {
+        accessKeyId: process.env.R2_ACCESS_KEY_ID,
+        secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+      },
+      forcePathStyle: true,
+    });
+  }
+
+  return cachedClient;
+}
 
 export async function listR2(prefix = 'prints/') {
-  const out = await r2Client.send(
-    new ListObjectsV2Command({ Bucket: process.env.R2_BUCKET!, Prefix: prefix })
-  );
-  return (out.Contents || []).map((o) => o.Key!).filter(Boolean);
+  const client = getR2Client();
+
+  if (!client) {
+    console.warn('Cloudflare R2 credentials are not configured. Showing an empty gallery.');
+    return [];
+  }
+
+  try {
+    const out = await client.send(
+      new ListObjectsV2Command({ Bucket: process.env.R2_BUCKET, Prefix: prefix })
+    );
+    return (out.Contents || []).map((o) => o.Key!).filter(Boolean);
+  } catch (error) {
+    console.error('Failed to list objects from Cloudflare R2.', error);
+    return [];
+  }
 }
 
 export function r2PublicUrl(key: string) {
-  const base = process.env.R2_PUBLIC_URL || process.env.R2_ENDPOINT!;
-  return `${base.replace(/\/$/, '')}/${key}`;
+  if (/^https?:\/\//.test(key)) {
+    return key;
+  }
+
+  const base = process.env.R2_PUBLIC_URL || process.env.R2_ENDPOINT;
+  if (!base) {
+    return '/placeholder-image.svg';
+  }
+
+  const normalizedBase = base.replace(/\/$/, '');
+  const normalizedKey = key.replace(/^\//, '');
+  return `${normalizedBase}/${normalizedKey}`;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,26 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: "var(--background)",
+        foreground: "var(--foreground)",
+        accent: "var(--accent)",
+        muted: "var(--muted)",
+      },
+      fontFamily: {
+        sans: ["var(--font-inter)", "system-ui", "sans-serif"],
+        serif: ["var(--font-playfair)", "serif"],
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- restore Tailwind processing by replacing the Tailwind CSS import with the framework directives and adding CSS variables for fallback fonts
- remove `next/font/google` usage in the root layout and configure Tailwind via a new `tailwind.config.ts` so the build no longer depends on external font downloads
- guard the Cloudflare R2 client creation against missing credentials and serve a placeholder image when no public base URL is configured

## Testing
- npm run lint *(fails: pre-existing lint errors in scripts)*
- npm run build *(fails: Stripe API version type mismatch in scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68c879e22ddc8320821e1d17b6bef0b1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added fade-in-up animation for smoother entrances.
  * Custom scrollbar styling.
* Style
  * Standardized fonts; body uses Inter by default.
  * Improved image rendering (responsive max-width/auto-height).
* Bug Fixes
  * Gallery and asset URLs now handle missing storage credentials gracefully, showing an empty state and a placeholder image instead of errors.
  * Accepts absolute image URLs without rewriting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->